### PR TITLE
allow both tensorflow imports, add an example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+mai.egg-info

--- a/README.md
+++ b/README.md
@@ -13,3 +13,32 @@ The ***Music AI Tutorial*** was developed for the course ***MUSC 80L: Artificial
 ### Thanks!
 This project is in ongoing development, so please check back for updates!
 
+### Local Installation
+
+If you want to use the mai package locally (not in Collab/Jupyter notebook), you can install it with pip:
+
+```bash
+python3 -m pip install git+https://github.com/davidkant/mai
+# or
+git clone https://github.com/davidkant/mai
+python3 -m pip install ./mai
+```
+
+The `tensorflow`/`keras` dependencies could be tricky to install sometimes, [see docs](https://www.tensorflow.org/install/pip) if you're having issues.
+
+Then, you can import it like any other package. Without setting up the proper libraries for audio playback, it might be easiest to save to `MIDI`.
+
+```python
+import mai
+
+midi = mai.make_music_heterophonic(
+    [[35, 35], [35, 38, 38], [42, 42, 42, 42, 42, 42, 42, 42, 49]],
+    durs=[[1.3, 1.3], [0.65, 1.3, 1.3], [0.33, 0.33, 0.33, 0.33, 0.33, 0.33, 0.33, 0.33, 1.95]],
+    is_drum=True,
+    format="MIDI"
+)
+
+midi.write("my_music.mid")
+```
+
+Then you can visualize it with an online tool or with a tool like [fluidsynth](https://www.fluidsynth.org/) or [timidity](https://timidity.sourceforge.net/). Note these typically require you to setup a [soundfont](https://en.wikipedia.org/wiki/SoundFont)

--- a/mai/nn.py
+++ b/mai/nn.py
@@ -1,8 +1,17 @@
 import keras
 from keras.models import Sequential
 from keras.layers import Dense, Activation, Dropout
-from keras.optimizers import gradient_descent_v2
 import numpy as np
+
+# handle both cases as described here:
+# https://github.com/davidkant/mai/commit/6b152a43fccf5e01c3dc6e24417607fa254f8bbf
+# https://github.com/tensorflow/tensorflow/issues/23728
+try:
+    from keras.optimizers import SGD
+except: # if cant import, try the other PATH
+    from keras.optimizers import gradient_descent_v2
+
+    SGD = gradient_descent_v2.SGD
 
 # Network Architectures ----------------------------------------------------------------
 
@@ -17,7 +26,7 @@ def singleLayerPerceptron(units=2, input_dim=2, lr=0.03, decay=1e-6, momentum=0.
     
     # compile the model
     model.compile(loss='binary_crossentropy' if units == 2 else 'categorical_crossentropy',
-                  optimizer=gradient_descent_v2.SGD(lr=lr, decay=decay, momentum=momentum, nesterov=nesterov),
+                  optimizer=SGD(lr=lr, decay=decay, momentum=momentum, nesterov=nesterov),
                   metrics=['accuracy'])
     
     return model
@@ -42,7 +51,7 @@ def multiLayerPerceptron(num_neurons=4, num_hidden_layers=1, input_dim=2, output
 
     # compile the model
     model.compile(loss='binary_crossentropy' if output_dim == 2 else 'categorical_crossentropy',
-                  optimizer=gradient_descent_v2.SGD(lr=lr, decay=decay, momentum=momentum, nesterov=nesterov),
+                  optimizer=SGD(lr=lr, decay=decay, momentum=momentum, nesterov=nesterov),
                   metrics=['accuracy'])
 
     return model


### PR DESCRIPTION
wanted to get my old assignment code working again, so I thought I'd contribute back some changes I had to make

For whatever reason, [#19](https://github.com/davidkant/mai/issues/19) actually breaks my import, I made sure I was on the latest versions of tensorflow/keras but the old code works for me

So, instead of reverting, I thought it would be best to just support both syntaxes (since what tensorflow version someone is sometimes different since some other package installs a specific version). If it causes an `ImportError`, it will try the other syntax, and then sets both to the `SDG` class as its used below. Can compare against [the commit](https://github.com/davidkant/mai/commit/6b152a43fccf5e01c3dc6e24417607fa254f8bbf)

Also added a minimal example to the readme and links to some docs if anyone else wanted to try setting up a midi player locally, I couldnt get fluidsynth working on my machine because of [JACK errors](https://exobrain.sean.fish/devlog/sonic_pi/), but was able to get timidity to.